### PR TITLE
fixed stop upload callback on android

### DIFF
--- a/src/android/FileTransferBackground.java
+++ b/src/android/FileTransferBackground.java
@@ -10,7 +10,7 @@ import net.gotev.uploadservice.MultipartUploadRequest;
 import net.gotev.uploadservice.ServerResponse;
 import net.gotev.uploadservice.UploadInfo;
 import net.gotev.uploadservice.UploadService;
-import net.gotev.uploadservice.UploadStatusDelegate;
+import net.gotev.uploadservice.UploadServiceBroadcastReceiver;
 import net.gotev.uploadservice.okhttp.OkHttpStack;
 
 import org.apache.cordova.CallbackContext;
@@ -22,27 +22,119 @@ import org.json.JSONObject;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+
 
 public class FileTransferBackground extends CordovaPlugin {
 
   private final String uploadDirectoryName = "FileTransferBackground";
   private Storage storage;
   private CallbackContext uploadCallback;
-  private CallbackContext cancelCallback;
   private NetworkMonitor networkMonitor;
   private Long lastProgressTimestamp = 0L;
+  private HashMap<String,CallbackContext> cancelUploadCallbackMap = new HashMap();
+  private boolean hasBeenDestroyed = false;
+
+  private UploadServiceBroadcastReceiver broadcastReceiver = new UploadServiceBroadcastReceiver() {
+    @Override
+    public void onProgress(Context context, UploadInfo uploadInfo) {
+
+      try {
+        Long currentTimestamp = System.currentTimeMillis()/1000;
+        if (currentTimestamp - lastProgressTimestamp >=1) {
+          LogMessage("id:" + uploadInfo.getUploadId() + " progress: " + uploadInfo.getProgressPercent());
+          lastProgressTimestamp = currentTimestamp;
+
+          if (uploadCallback != null && !hasBeenDestroyed) {
+            JSONObject objResult = new JSONObject();
+            objResult.put("id", uploadInfo.getUploadId());
+            objResult.put("progress", uploadInfo.getProgressPercent());
+            objResult.put("state", "UPLOADING");
+            PluginResult progressUpdate = new PluginResult(PluginResult.Status.OK, objResult);
+            progressUpdate.setKeepCallback(true);
+            uploadCallback.sendPluginResult(progressUpdate);
+          }
+        }
+
+      } catch (Exception e) {
+        e.printStackTrace();
+      }
+    }
+
+    @Override
+    public void onError(Context context, UploadInfo uploadInfo, Exception exception) {
+      LogMessage("App onError: " + exception);
+
+      try {
+        updateStateForUpload(uploadInfo.getUploadId(), UploadState.FAILED, null);
+
+        if (uploadCallback !=null && !hasBeenDestroyed){
+          JSONObject errorObj = new JSONObject();
+          errorObj.put("id", uploadInfo.getUploadId());
+          errorObj.put("error", "execute failed");
+          errorObj.put("state", "FAILED");
+          PluginResult errorResult = new PluginResult(PluginResult.Status.ERROR, errorObj);
+          errorResult.setKeepCallback(true);
+          uploadCallback.sendPluginResult(errorResult);
+        }
+
+
+      } catch (Exception e) {
+        e.printStackTrace();
+      }
+    }
+
+    @Override
+    public void onCompleted(Context context, UploadInfo uploadInfo, ServerResponse serverResponse) {
+
+      try {
+        LogMessage("server response : " + serverResponse.getBodyAsString() +" for "+uploadInfo.getUploadId()) ;
+        updateStateForUpload(uploadInfo.getUploadId(), UploadState.UPLOADED, serverResponse.getBodyAsString());
+        if (uploadCallback !=null  && !hasBeenDestroyed){
+          JSONObject objResult = new JSONObject();
+          objResult.put("id", uploadInfo.getUploadId());
+          objResult.put("completed", true);
+          objResult.put("serverResponse", serverResponse.getBodyAsString());
+          objResult.put("state", "UPLOADED");
+          objResult.put("statusCode", serverResponse.getHttpCode());
+          PluginResult completedUpdate = new PluginResult(PluginResult.Status.OK, objResult);
+          completedUpdate.setKeepCallback(true);
+          uploadCallback.sendPluginResult(completedUpdate);
+        }
+
+      } catch (Exception e) {
+        e.printStackTrace();
+      }
+    }
+
+    @Override
+    public void onCancelled(Context context, UploadInfo uploadInfo) {
+      try {
+        LogMessage("upload cancelled "+uploadInfo.getUploadId());
+        removeUploadInfoFile(uploadInfo.getUploadId());
+        PluginResult result = new PluginResult(PluginResult.Status.OK);
+        result.setKeepCallback(true);
+        CallbackContext cancelCallback = cancelUploadCallbackMap.get(uploadInfo.getUploadId());
+        if (cancelCallback !=null  && !hasBeenDestroyed)
+          cancelCallback.sendPluginResult(result);
+      } catch (Exception e) {
+        e.printStackTrace();
+      }
+    }
+  };
 
   @Override
   public boolean execute(String action, JSONArray args, final CallbackContext callbackContext){
 
     try {
-      uploadCallback = callbackContext;
       if (action.equalsIgnoreCase("initManager")) {
+        uploadCallback = callbackContext;
         this.initManager(args.length() > 0 ? args.get(0).toString() : null, callbackContext);
       } else if (action.equalsIgnoreCase("removeUpload")) {
         this.removeUpload(args.length() > 0 ? args.get(0).toString() : null, callbackContext);
       } else {
+        uploadCallback = callbackContext;
         upload(args.length() > 0 ? (JSONObject) args.get(0) : null, uploadCallback);
       }
     } catch (Exception ex) {
@@ -65,96 +157,13 @@ public class FileTransferBackground extends CordovaPlugin {
       LogMessage("upload with id "+payload.id + " is already being uploaded. ignoring re-upload request");
       return;
     }
+    LogMessage("adding upload "+payload.id);
     this.createUploadInfoFile(payload.id, jsonPayload);
-    final FileTransferBackground self = this;
     if (NetworkMonitor.isConnected) {
       MultipartUploadRequest request = new MultipartUploadRequest(this.cordova.getActivity().getApplicationContext(), payload.id,payload.serverUrl)
         .addFileToUpload(payload.filePath, payload.fileKey)
-        .setMaxRetries(0)
-        .setDelegate(new UploadStatusDelegate() {
-          @Override
-          public void onProgress(Context context, UploadInfo uploadInfo) {
+        .setMaxRetries(0);
 
-            try {
-              Long currentTimestamp = System.currentTimeMillis()/1000;
-              if (currentTimestamp - lastProgressTimestamp >=1) {
-                LogMessage("id:" + payload.id + " progress: " + uploadInfo.getProgressPercent());
-                lastProgressTimestamp = currentTimestamp;
-                JSONObject objResult = new JSONObject();
-                objResult.put("id", payload.id);
-                objResult.put("progress", uploadInfo.getProgressPercent());
-                objResult.put("state", "UPLOADING");
-                PluginResult progressUpdate = new PluginResult(PluginResult.Status.OK, objResult);
-                progressUpdate.setKeepCallback(true);
-                if (callbackContext != null && self.webView != null)
-                  callbackContext.sendPluginResult(progressUpdate);
-              }
-
-            } catch (Exception e) {
-              e.printStackTrace();
-            }
-          }
-
-          @Override
-          public void onError(Context context, UploadInfo uploadInfo, Exception exception) {
-            LogMessage("App onError: " + exception);
-
-            try {
-              updateStateForUpload(payload.id, UploadState.FAILED, null);
-
-              JSONObject errorObj = new JSONObject();
-              errorObj.put("id", payload.id);
-              errorObj.put("error", "execute failed");
-              errorObj.put("state", "FAILED");
-              PluginResult errorResult = new PluginResult(PluginResult.Status.ERROR, errorObj);
-              errorResult.setKeepCallback(true);
-              if (callbackContext !=null  && self.webView !=null )
-                callbackContext.sendPluginResult(errorResult);
-
-            } catch (Exception e) {
-              e.printStackTrace();
-            }
-          }
-
-          @Override
-          public void onCompleted(Context context, UploadInfo uploadInfo, ServerResponse serverResponse) {
-
-            try {
-              LogMessage("server response : " + serverResponse.getBodyAsString());
-              updateStateForUpload(payload.id, UploadState.UPLOADED, serverResponse.getBodyAsString());
-
-              JSONObject objResult = new JSONObject();
-              objResult.put("id", payload.id);
-              objResult.put("completed", true);
-              objResult.put("serverResponse", serverResponse.getBodyAsString());
-              objResult.put("state", "UPLOADED");
-              objResult.put("statusCode", serverResponse.getHttpCode());
-              PluginResult completedUpdate = new PluginResult(PluginResult.Status.OK, objResult);
-              completedUpdate.setKeepCallback(true);
-              if (callbackContext !=null  && self.webView !=null)
-                callbackContext.sendPluginResult(completedUpdate);
-            } catch (Exception e) {
-              e.printStackTrace();
-            }
-          }
-
-          @Override
-          public void onCancelled(Context context, UploadInfo uploadInfo) {
-            try {
-              LogMessage("upload cancelled "+uploadInfo.getUploadId());
-              removeUploadInfoFile(uploadInfo.getUploadId());
-              JSONObject objResult = new JSONObject();
-              objResult.put("id", uploadInfo.getUploadId());
-              PluginResult result = new PluginResult(PluginResult.Status.OK, objResult);
-              result.setKeepCallback(true);
-              if (cancelCallback !=null  && self.webView !=null)
-                cancelCallback.sendPluginResult(result);
-              cancelCallback = null;
-            } catch (Exception e) {
-              e.printStackTrace();
-            }
-          }
-        });
 
       for (String key : payload.parameters.keySet()) {
         request.addParameter(key, payload.parameters.get(key));
@@ -179,9 +188,17 @@ public class FileTransferBackground extends CordovaPlugin {
   private void removeUpload(String fileId, CallbackContext callbackContext) {
     try {
       if (fileId == null)
+        throw new Exception("missing upload id");
+      if (!UploadService.getTaskList().contains(fileId)){
+        LogMessage("request to cancel upload, "+fileId + " is not in progress, returning callback");
+        PluginResult result = new PluginResult(PluginResult.Status.OK);
+        result.setKeepCallback(true);
+        callbackContext.sendPluginResult(result);
         return;
+      }
+      LogMessage("cancel upload "+fileId);
+      cancelUploadCallbackMap.put(fileId,callbackContext);
       UploadService.stopUpload(fileId);
-      cancelCallback = callbackContext;
     } catch (Exception e) {
       e.printStackTrace();
       PluginResult errorResult = new PluginResult(PluginResult.Status.ERROR, e.toString());
@@ -254,6 +271,7 @@ public class FileTransferBackground extends CordovaPlugin {
       UploadService.UPLOAD_POOL_SIZE = 1;
       UploadService.NAMESPACE = "com.spoon.backgroundupload";
 
+      broadcastReceiver.register(cordova.getActivity().getApplicationContext());
       storage = SimpleStorage.getInternalStorage(this.cordova.getActivity().getApplicationContext());
       storage.createDirectory(uploadDirectoryName);
       LogMessage("created working directory ");
@@ -318,8 +336,12 @@ public class FileTransferBackground extends CordovaPlugin {
   }
 
   public void onDestroy() {
-    Log.d("FileTransferBackground"," FileTransferBackground onDestroy");
-    if(networkMonitor != null)
+    LogMessage("plugin onDestroy, unsubscribing all callbacks");
+    hasBeenDestroyed = true;
+    if (networkMonitor != null)
       networkMonitor.stopMonitoring();
+    //broadcastReceiver.unregister(cordova.getActivity().getApplicationContext());
   }
+
+
 }


### PR DESCRIPTION
If a request to stop an upload which is not being active is made, the callback will be returned immediately else it will be sent when `onCancelled` event is received.

This PR makes uploads events to be received without having to put an upload at first. This also fixes the issue `Application attempted to call on a destroyed WebView java.lang.Throwable at` when an upload callback is received but the application has been destroyed.