### PR TITLE
Restore session when app is launched in background on ios

### DIFF
--- a/src/ios/AppDelegate+upload.m
+++ b/src/ios/AppDelegate+upload.m
@@ -101,6 +101,9 @@ NSString const *callbackKey = @"com.bg.category.block.unique.key";
     // delegate method can call it.
     
     self.backgroundCompletionBlock = completionHandler;
+    //at this point we know that we are being invoked in background when the daemon has some upload information
+    //resume the session to receive progress of the uploads
+    [[FileUploadManager sharedInstance] start];
 }
 
 


### PR DESCRIPTION
When the app is resumed from suspended state because ios daemon has completed the upload, the session needs to be resumed to be able to get proper server response in 
`- (void)URLSession:(NSURLSession *)session dataTask:(NSURLSessionDataTask *)dataTask didReceiveData:(NSData *)data`
More info:
https://www.objc.io/issues/5-ios7/multitasking/