### PR TITLE
Prevent duplicate check in pending list when calling upload

### DIFF
--- a/src/android/FileTransferBackground.java
+++ b/src/android/FileTransferBackground.java
@@ -167,18 +167,6 @@ public class FileTransferBackground extends CordovaPlugin {
       LogMessage("upload with id "+payload.id + " is already being uploaded. ignoring re-upload request");
       return;
     }
-    try {
-      ArrayList<JSONObject> existingUploads = getUploadHistory();
-      for (JSONObject upload : existingUploads) {
-        String id = upload.getString("id");
-        if (id.equalsIgnoreCase(payload.id)) {
-          LogMessage("upload with id "+payload.id + " is already exists in upload queue. ignoring re-upload request");
-          return;
-        }
-      }
-    } catch (Exception e) {
-      e.printStackTrace();
-    }
 
     LogMessage("adding upload "+payload.id);
     this.createUploadInfoFile(payload.id, jsonPayload);


### PR DESCRIPTION
Upload being ignored when network becomes available on Android:
https://github.com/spoonconsulting/cordova-plugin-background-upload/issues/48