### PR TITLE
V2 Nullpointer Exception on destroy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spoonconsulting/cordova-plugin-background-upload",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Cordova plugin for uploading file in the background",
   "cordova": {
     "id": "@spoonconsulting/cordova-plugin-background-upload",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="@spoonconsulting/cordova-plugin-background-upload" version="2.0.3">
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="@spoonconsulting/cordova-plugin-background-upload" version="2.0.4">
     <name>Cordova Background Upload Plugin</name>
     <description>Background Upload plugin for Cordova</description>
     <license>ISC</license>

--- a/src/android/FileTransferBackground.java
+++ b/src/android/FileTransferBackground.java
@@ -411,8 +411,8 @@ public class FileTransferBackground extends CordovaPlugin {
 
     public void destroy() {
         this.ready = false;
-        this.networkObservable.dispose();
-        this.globalObserver.unregister();
+        if (this.networkObservable != null) { this.networkObservable.dispose(); }
+        if (this.globalObserver != null) { this.globalObserver.unregister(); }
         this.networkObservable = null;
         this.globalObserver = null;
     }


### PR DESCRIPTION
Caused by: java.lang.NullPointerException: 
at com.spoon.backgroundfileupload.FileTransferBackground.destroy (FileTransferBackground.java:414)
at com.spoon.backgroundfileupload.FileTransferBackground.onDestroy (FileTransferBackground.java:409)
at org.apache.cordova.PluginManager.onDestroy (PluginManager.java:297)
at org.apache.cordova.CordovaWebViewImpl.handleDestroy (CordovaWebViewImpl.java:502)
at org.apache.cordova.CordovaActivity.onDestroy (CordovaActivity.java:317)
at android.app.Activity.performDestroy (Activity.java:8459)
at android.app.Instrumentation.callActivityOnDestroy (Instrumentation.java:1344)
at android.app.ActivityThread.performDestroyActivity (ActivityThread.java:5587