### PR TITLE
Remove WorkManager Constraint

### DIFF
--- a/src/android/FileTransferBackground.java
+++ b/src/android/FileTransferBackground.java
@@ -333,10 +333,6 @@ public class FileTransferBackground extends CordovaPlugin {
         Log.d(TAG, "startUpload: Starting work via work manager");
 
         OneTimeWorkRequest.Builder workRequestBuilder = new OneTimeWorkRequest.Builder(UploadTask.class)
-                .setConstraints(new Constraints.Builder()
-                        .setRequiredNetworkType(NetworkType.CONNECTED)
-                        .build()
-                )
                 .keepResultsForAtLeast(0, TimeUnit.MILLISECONDS)
                 .setBackoffCriteria(BackoffPolicy.LINEAR, 30, TimeUnit.SECONDS)
                 .addTag(FileTransferBackground.WORK_TAG_UPLOAD)


### PR DESCRIPTION
On some Devices uploading 300 images at a time blocks queue of uploads. Removing Constraints in the WorkRequest helps to allow upload the image normally.