### PR TITLE
Revert to using getThreadPool

### DIFF
--- a/src/android/FileTransferBackground.java
+++ b/src/android/FileTransferBackground.java
@@ -121,11 +121,11 @@ public class FileTransferBackground extends CordovaPlugin {
 
     @Override
     public boolean execute(String action, JSONArray args, final CallbackContext callbackContext) {
-        if(executorService == null) {
+        if (executorService == null) {
             executorService = Executors.newScheduledThreadPool(4);
         }
 
-        executorService.schedule(() -> {
+        cordova.getThreadPool().execute(() -> {
             try {
                 switch (action) {
                     case "initManager":
@@ -151,7 +151,7 @@ public class FileTransferBackground extends CordovaPlugin {
                 callbackContext.sendPluginResult(result);
                 exception.printStackTrace();
             }
-        } , 0, TimeUnit.MILLISECONDS);
+        });
 
         return true;
     }


### PR DESCRIPTION
https://github.com/apache/cordova-android/blob/2a84d7c44ddf5eb169f34a2448915a53d0a30fcd/framework/src/org/apache/cordova/CordovaInterfaceImpl.java#L56

https://stackoverflow.com/questions/949355/executors-newcachedthreadpool-versus-executors-newfixedthreadpool