### PR TITLE
Change form uploads to use multipart/mixed on Android

### DIFF
--- a/src/android/UploadTask.java
+++ b/src/android/UploadTask.java
@@ -357,6 +357,7 @@ public final class UploadTask extends Worker {
         }
 
         bodyBuilder.addFormDataPart(fileKey, filepath, fileRequestBody);
+        bodyBuilder.setType(MultipartBody.FORM);
 
         // Start build request
         String method = getInputData().getString(KEY_INPUT_HTTP_METHOD);


### PR DESCRIPTION
Changes the content type of the form post to use `multipart/form-data` rather than `multipart/mixed` which some target servers do not know how to handle.

This makes it match what is sent on the iOS platform as well.