### PR TITLE
Update dependency of cordova-plugin-file version

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -13,7 +13,7 @@
     </engines>
    <dependency id="cordova-plugin-androidx" version="1.0.2"/>
    <dependency id="cordova-plugin-androidx-adapter" version="1.1.0"/>
-   <dependency id="cordova-plugin-file" version="6.0.2"/>
+   <dependency id="cordova-plugin-file" version=">=7.0.0"/>
     <platform name="android">
         <framework src="androidx.work:work-runtime:2.7.1" />
         <framework src="com.squareup.okhttp3:okhttp:4.9.3" />


### PR DESCRIPTION
Update dependency of cordova-plugin-file version to match that of other cordova plugins such as cordova-plugin-file-transfer