### PR TITLE
Fix Background Uploads on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [4.1.3](https://github.com/spoonconsulting/cordova-plugin-background-upload/compare/4.1.2...4.1.3) (2026-01-24)
+* **android:** Prevent background upload from stopping when the app is terminated
+
 ## [4.1.2](https://github.com/spoonconsulting/cordova-plugin-background-upload/compare/4.1.1...4.1.2) (2024-11-05)
 * **android:** Return upload start and end time in upload response
 * **iOS:** Return upload start and end time in upload response

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@spoonconsulting/cordova-plugin-background-upload",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@spoonconsulting/cordova-plugin-background-upload",
-      "version": "4.1.2",
+      "version": "4.1.3",
       "license": "Apache-2.0",
       "devDependencies": {
         "cordova-paramedic": "git+https://github.com/apache/cordova-paramedic.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spoonconsulting/cordova-plugin-background-upload",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "description": "Cordova plugin for uploading file in the background",
   "cordova": {
     "id": "@spoonconsulting/cordova-plugin-background-upload",

--- a/plugin.xml
+++ b/plugin.xml
@@ -29,6 +29,8 @@
             </feature>
         </config-file>
         <config-file target="AndroidManifest.xml" parent="/manifest">
+            <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+            <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
             <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
             <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
             <uses-permission android:name="android.permission.INTERNET" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="@spoonconsulting/cordova-plugin-background-upload" version="4.1.2">
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="@spoonconsulting/cordova-plugin-background-upload" version="4.1.3">
     <name>Cordova Background Upload Plugin</name>
     <description>Background Upload plugin for Cordova</description>
     <license>ISC</license>

--- a/src/android/UploadNotification.java
+++ b/src/android/UploadNotification.java
@@ -126,8 +126,8 @@ public class UploadNotification {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             return new ForegroundInfo(notificationId, notificationBuilder.build(),
                     ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC);
-        } else {
-            return new ForegroundInfo(notificationId, notificationBuilder.build());
-        }
+        } 
+
+        return new ForegroundInfo(notificationId, notificationBuilder.build());
     }
 }

--- a/src/android/UploadNotification.java
+++ b/src/android/UploadNotification.java
@@ -14,8 +14,10 @@ import android.util.Log;
 import androidx.annotation.IntegerRes;
 import androidx.annotation.RequiresApi;
 import androidx.core.app.NotificationCompat;
+import androidx.work.ForegroundInfo;
 import androidx.work.WorkInfo;
 import androidx.work.WorkManager;
+import android.content.pm.ServiceInfo;
 
 import java.util.Collections;
 import java.util.List;
@@ -82,7 +84,7 @@ public class UploadNotification {
         Notification notification = notificationBuilder.build();
         notification.flags |= Notification.FLAG_NO_CLEAR;
         notification.flags |= Notification.FLAG_ONGOING_EVENT;
-        return  notification;
+        return notification;
     }
 
     @RequiresApi(api = Build.VERSION_CODES.O)
@@ -103,7 +105,9 @@ public class UploadNotification {
         PendingIntent pendingIntent = PendingIntent.getActivity(context, 0, notificationIntent, pendingIntentFlag);
 
         // TODO: click intent open app
-        @SuppressLint("ResourceType") NotificationCompat.Builder uploadNotificationBuilder = new NotificationCompat.Builder(context, UploadTask.NOTIFICATION_CHANNEL_ID)
+        @SuppressLint("ResourceType")
+        NotificationCompat.Builder uploadNotificationBuilder = new NotificationCompat.Builder(context,
+                UploadTask.NOTIFICATION_CHANNEL_ID)
                 .setContentTitle(notificationTitle)
                 .setTicker(notificationTitle)
                 .setSmallIcon(notificationIconRes)
@@ -116,5 +120,14 @@ public class UploadNotification {
                 .addAction(notificationIconRes, "Open", pendingIntent);
 
         return uploadNotificationBuilder;
+    }
+
+    public ForegroundInfo getForegroundInfo() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            return new ForegroundInfo(notificationId, notificationBuilder.build(),
+                    ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC);
+        } else {
+            return new ForegroundInfo(notificationId, notificationBuilder.build());
+        }
     }
 }

--- a/src/android/UploadTask.java
+++ b/src/android/UploadTask.java
@@ -7,6 +7,7 @@ import android.util.Log;
 import android.webkit.MimeTypeMap;
 
 import androidx.annotation.NonNull;
+import androidx.work.ForegroundInfo;
 import androidx.work.Data;
 import androidx.work.Worker;
 import androidx.work.WorkerParameters;
@@ -155,7 +156,7 @@ public final class UploadTask extends Worker {
     @NonNull
     @Override
     public Result doWork() {
-        if(!hasNetworkConnection()) {
+        if (!hasNetworkConnection()) {
             return Result.retry();
         }
 
@@ -395,10 +396,21 @@ public final class UploadTask extends Worker {
         Log.d(TAG, "Upload Notification");
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
             setForegroundAsync(uploadForegroundNotification.getForegroundInfo(getApplicationContext()));
-        } else  {
+        } else {
             uploadNotification.updateProgress();
         }
         Log.d(TAG, "Upload Notification Exit");
+    }
+
+    @NonNull
+    @Override
+    public ForegroundInfo getForegroundInfo() {
+        Log.d(TAG, "getForegroundInfo: Promoting to foreground service");
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+            return uploadForegroundNotification.getForegroundInfo(getApplicationContext());
+        } else {
+            return uploadNotification.getForegroundInfo();
+        }
     }
 
     private synchronized boolean hasNetworkConnection() {

--- a/src/android/UploadTask.java
+++ b/src/android/UploadTask.java
@@ -408,9 +408,9 @@ public final class UploadTask extends Worker {
         Log.d(TAG, "getForegroundInfo: Promoting to foreground service");
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
             return uploadForegroundNotification.getForegroundInfo(getApplicationContext());
-        } else {
-            return uploadNotification.getForegroundInfo();
-        }
+        } 
+
+        return uploadNotification.getForegroundInfo();
     }
 
     private synchronized boolean hasNetworkConnection() {

--- a/src/android/UploadTask.java
+++ b/src/android/UploadTask.java
@@ -405,7 +405,6 @@ public final class UploadTask extends Worker {
     @NonNull
     @Override
     public ForegroundInfo getForegroundInfo() {
-        Log.d(TAG, "getForegroundInfo: Promoting to foreground service");
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
             return uploadForegroundNotification.getForegroundInfo(getApplicationContext());
         } 


### PR DESCRIPTION
This PR fixes an issue where background uploads were being terminated by the OS when the app was killed on Android 12+ devices. The fix ensures the UploadTask is correctly promoted to a Foreground Service, allowing it to persist independently of the app process.

On Android 12+, WorkManager requires Expedited work requests to implement getForegroundInfo() so the system can display a notification if the task runs long. The plugin was missing this implementation, causing the system to deny the expedited execution or kill the worker when the app process died. Additionally, the worker was not explicitly calling setForegroundAsync for Android 12+, relying on default behavior which proved unreliable for app-kill scenarios.

Solution:
Implemented getForegroundInfo(): Overrode this method in UploadTask.java to return a valid ForegroundInfo object containing the upload notification.